### PR TITLE
CNTRLPLANE-323: No pod restoration to avoid NodeSelector issues with podPlugin

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,17 +14,11 @@ func main() {
 }
 
 func newHCPBackupPlugin(logger logrus.FieldLogger) (interface{}, error) {
-	return core.NewBackupPlugin(logger.WithFields(
-		logrus.Fields{
-			"type": "core-backup",
-		},
-	))
+	logger.Info("Initializing HCP Backup Plugin")
+	return core.NewBackupPlugin()
 }
 
 func newHCPRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
-	return core.NewRestorePlugin(logger.WithFields(
-		logrus.Fields{
-			"type": "core-restore",
-		},
-	))
+	logger.Info("Initializing HCP Restore Plugin")
+	return core.NewRestorePlugin()
 }

--- a/pkg/core/types/types.go
+++ b/pkg/core/types/types.go
@@ -29,6 +29,8 @@ type BackupOptions struct {
 	DataUploadCheckPace time.Duration
 	// ManagedServices is a flag to indicate if the backup is done for ManagedServices like ROSA, ARO, etc.
 	ManagedServices bool
+	// PluginVerbosityLevel is the verbosity level of the plugin.
+	PluginVerbosityLevel string
 }
 
 type RestoreOptions struct {
@@ -38,4 +40,6 @@ type RestoreOptions struct {
 	ReadoptNodes bool
 	// ManagedServices is a flag to indicate if the backup is done for ManagedServices like ROSA, ARO, etc.
 	ManagedServices bool
+	// PluginVerbosityLevel is the verbosity level of the plugin.
+	PluginVerbosityLevel string
 }

--- a/pkg/core/validation/backup.go
+++ b/pkg/core/validation/backup.go
@@ -16,12 +16,12 @@ type BackupValidator interface {
 }
 
 type BackupPluginValidator struct {
-	Log logrus.FieldLogger
+	Log *logrus.Logger
 }
 
 func (p *BackupPluginValidator) ValidatePluginConfig(config map[string]string) (*plugtypes.BackupOptions, error) {
 	// Validate the plugin configuration
-	p.Log.Debug("validating plugin configuration")
+	p.Log.Infof("validating plugin configuration")
 	if len(config) == 0 {
 		p.Log.Debug("no configuration provided")
 		return &plugtypes.BackupOptions{}, nil
@@ -32,23 +32,31 @@ func (p *BackupPluginValidator) ValidatePluginConfig(config map[string]string) (
 		p.Log.Debugf("configuration key: %s, value: %s", key, value)
 		switch key {
 		case "migration":
+			p.Log.Debugf("reading/parsing migration %s", value)
 			bo.Migration = value == "true"
 		case "readoptNodes":
+			p.Log.Debugf("reading/parsing readoptNodes %s", value)
 			bo.ReadoptNodes = value == "true"
 		case "managedServices":
+			p.Log.Debugf("reading/parsing managedServices %s", value)
 			bo.ManagedServices = value == "true"
 		case "dataUploadTimeout":
+			p.Log.Debugf("reading/parsing dataUploadTimeout %s", value)
 			minutes, err := strconv.ParseInt(value, 10, 64)
 			if err != nil {
 				return nil, fmt.Errorf("error parsing dataUploadTimeout: %s", err.Error())
 			}
 			bo.DataUploadTimeout = time.Duration(minutes)
 		case "dataUploadCheckPace":
+			p.Log.Debugf("reading/parsing dataUploadCheckPace %s", value)
 			seconds, err := strconv.ParseInt(value, 10, 64)
 			if err != nil {
 				return nil, fmt.Errorf("error parsing dataUploadCheckPace: %s", err.Error())
 			}
 			bo.DataUploadCheckPace = time.Duration(seconds)
+		case "pluginVerbosityLevel":
+			p.Log.Debugf("reading/parsing pluginVerbosityLevel %s", value)
+			bo.PluginVerbosityLevel = value
 		default:
 			p.Log.Warnf("unknown configuration key: %s with value %s", key, value)
 		}

--- a/pkg/core/validation/restore.go
+++ b/pkg/core/validation/restore.go
@@ -34,11 +34,17 @@ func (p *RestorePluginValidator) ValidatePluginConfig(config map[string]string) 
 		p.Log.Debugf("%s configuration key: %s, value: %s", p.LogHeader, key, value)
 		switch key {
 		case "migration":
+			p.Log.Debugf("reading/parsing migration %s", value)
 			bo.Migration = value == "true"
 		case "readoptNodes":
+			p.Log.Debugf("reading/parsing readoptNodes %s", value)
 			bo.ReadoptNodes = value == "true"
 		case "managedServices":
+			p.Log.Debugf("reading/parsing managedServices %s", value)
 			bo.ManagedServices = value == "true"
+		case "pluginVerbosityLevel":
+			p.Log.Debugf("reading/parsing pluginVerbosityLevel %s", value)
+			bo.PluginVerbosityLevel = value
 		default:
 			p.Log.Warnf("unknown configuration key: %s with value %s", key, value)
 		}


### PR DESCRIPTION
## What this PR does / why we need it
The HC has a feature to include NodeAffinity labels in the ETCD statefulSet, this is mostly to avoid issues scheduling pods in nodes which has difficulties to boot up like ROSA and their InfraNodes. This PR makes sure the pods included in the backup were not restored to avoid issues with nodeSelectors.

## What includes this PR
- Enhanced Logging with configurable debug mode (Enabled by default)
- No restoration of the pods even if those were backed up, but keeping the PVs and PVCs as they were

## Which issue(s) this PR fixes
Fixes #[CNTRLPLANE-323](https://issues.redhat.com/browse/CNTRLPLANE-323)