### PR TITLE
NO-JIRA: Hermeto: go mod vendor

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -667,8 +667,6 @@ k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/workqueue
-# k8s.io/component-base v0.30.1
-## explicit; go 1.22.0
 # k8s.io/klog/v2 v2.130.1
 ## explicit; go 1.18
 k8s.io/klog/v2


### PR DESCRIPTION
https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=67368291

```
Image build failed. Error in binary-container-hermeto: "step-binary-container-hermeto-run" exited with code 2
```

https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/work/tasks/8291/67368291/remote-sources.log

```
Processing remote source: remote-source
Fetching dependencies using Hermeto options: {"packages": [{"type": "gomod", "path": "."}], "flags": []}
2025-04-17 14:41:42,274 INFO Fetching the gomod dependencies at subpath .
2025-04-17 14:41:48,880 INFO go.mod reported versions: '1.22.1'[go], '-'[toolchain]
2025-04-17 14:41:48,881 INFO Using Go release: go1.21.0
2025-04-17 14:42:36,573 INFO Vendoring the gomod dependencies
2025-04-17 14:42:46,661 ERROR vendor/modules.txt changed after vendoring:
diff --git a/vendor/modules.txt b/vendor/modules.txt
index 978003f..a7b2df8 100644
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -667,8 +667,6 @@ k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/workqueue
-# k8s.io/component-base v0.30.1
-## explicit; go 1.22.0
 # k8s.io/klog/v2 v2.130.1
 ## explicit; go 1.18
 k8s.io/klog/v2
2025-04-17 14:42:48,258 ERROR PackageRejected: The content of the vendor directory is not consistent with go.mod. Please check the logs for more details.
Error: PackageRejected: The content of the vendor directory is not consistent with go.mod. Please check the logs for more details.
  Please try running `go mod vendor` and committing the changes.
  Note that you may need to `git add --force` ignored files in the vendor/ dir.
  Docs: https://github.com/hermetoproject/hermeto/blob/main/docs/gomod.md#vendoring
2025/04/17 14:42:48 Skipping step because a previous step failed
```

https://github.com/hermetoproject/hermeto/blob/main/docs/gomod.md#vendoring


> We generally discourage vendoring, but Hermeto does support processing repositories that contain vendored content. In this case, instead of a regular prefetching of dependencies, Hermeto will only validate if the contents of the vendor directory are consistent with what `go mod vendor` would produce. 


