### PR TITLE
CNTRLPLANE-720: Add Goreleaser for automatically generate the multiarch binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ go.work.sum
 .envrc
 
 # build output
+dist/
 _output/
 
 # Editors

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,54 @@
+project_name: hypershift-oadp-plugin
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod vendor
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    binary: hypershift-oadp-plugin-{{ .Os }}-{{ .Arch }}
+    main: ./main.go
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X github.com/openshift/hypershift-oadp-plugin/pkg/version.Version={{.Version}}
+      - -X github.com/openshift/hypershift-oadp-plugin/pkg/version.Commit={{.Commit}}
+      - -X github.com/openshift/hypershift-oadp-plugin/pkg/version.Date={{.Date}}
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}"
+    files:
+      - LICENSE
+      - README.md
+      - none*
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^ci:'
+
+release:
+  draft: true
+  mode: replace
+  header: |
+    ## HyperShift OADP Plugin {{ .Version }}
+
+    This is a release of the HyperShift OADP Plugin.
+  footer: |
+    ## Thanks!
+
+    Thanks to all contributors who helped with this release!

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18 AS build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 AS build
 WORKDIR /go/src/github.com/openshift/hypershift-oadp-plugin
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/hypershift-oadp-plugin .

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,39 @@
+package version
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var (
+	Version = getGitBranch()
+	Commit  = getGitCommit()
+	Date    = time.Now().Format(time.RFC3339)
+)
+
+// getGitBranch returns the current git branch
+func getGitBranch() string {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// getGitCommit returns the current git commit hash
+func getGitCommit() string {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// GetVersion returns version information
+func GetVersion() string {
+	return fmt.Sprintf("Version: %s\nCommit: %s\nDate: %s", Version, Commit, Date)
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,11 @@
+package version
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetVersion(t *testing.T) {
+	fmt.Println("Version Information:")
+	fmt.Println(GetVersion())
+}


### PR DESCRIPTION
## What this PR does / why we need it
- Binary multiarch support
- Automatic releases using goreleaser
- Some Make targets for enhancing dev experience

## Which issue(s) this PR fixes
- Binary multiarch support
