### PR TITLE
CNTRLPLANE-356: Oadp 1.5 floating tag

### DIFF
--- a/.tekton/hypershift-oadp-plugin-oadp-1-5-push.yaml
+++ b/.tekton/hypershift-oadp-plugin-oadp-1-5-push.yaml
@@ -546,6 +546,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+        - oadp-1.5
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
## What this PR does / why we need it

This will allow us to reference the floating tag in OADP.

## Which issue(s) this PR fixes
Fixes #[CNTRLPLANE-356](https://issues.redhat.com//browse/CNTRLPLANE-356)

## Checklist

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.