### PR TITLE
fix Dockerfile to match oadp plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,8 @@ WORKDIR /go/src/github.com/openshift/hypershift-oadp-plugin
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/hypershift-oadp-plugin .
 
-FROM busybox:1.37.0 AS busybox
-
-FROM scratch
+FROM registry.access.redhat.com/ubi9-minimal 
+RUN mkdir /plugins
 COPY --from=build /go/bin/hypershift-oadp-plugin /plugins/
-COPY --from=busybox /bin/cp /bin/cp
 USER 65532:65532
-ENTRYPOINT ["cp", "/plugins/hypershift-oadp-plugin", "/target/."]
+ENTRYPOINT ["/bin/bash", "-c", "cp /plugins/* /target/."]


### PR DESCRIPTION
busybox as pulled is not multiarch
OADP dev requires arm64
conform to ther oadp plugins
build like the hypershift plugin is built downstream for release