### PR TITLE
OADP-6147: break out if restore is not HCP

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -405,6 +405,11 @@ func GetHCPNamespace(name, namespace string) string {
 // Hypershift resources (HostedControlPlane and HostedCluster) exist in the cluster.
 // Returns true if the plugin should end execution (i.e., if this is not a Hypershift cluster).
 func ShouldEndPluginExecution(namespaces []string, client crclient.Client, log logrus.FieldLogger) bool {
+	if len(namespaces) == 0 {
+		log.Debug("No namespaces provided")
+		return true
+	}
+
 	// Check if HostedControlPlane exists
 	hcpList := &hyperv1.HostedControlPlaneList{}
 	for _, ns := range namespaces {

--- a/pkg/core/restore.go
+++ b/pkg/core/restore.go
@@ -128,14 +128,10 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	p.log.Debugf("Entering Hypershift restore plugin")
 	ctx := context.Context(p.ctx)
 
-	// logging may not be working :)
-	p.log.Info("WESHAY: get backup from restore")
-	p.log.Debug("WESHAY: get backup from restore")
-
 	// get the backup associated with the restore
 	backup := new(velerov1api.Backup)
 	err := p.client.Get(
-		context.TODO(),
+		ctx,
 		types.NamespacedName{
 			Namespace: input.Restore.Namespace,
 			Name:      input.Restore.Spec.BackupName,
@@ -148,9 +144,6 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		return nil, fmt.Errorf("fail to get backup for restore: %s", err.Error())
 	}
 
-	p.log.Info("WESHAY:BEGIN: if return early")
-	p.log.Debug("WESHAY:BEGIN: if return early")
-
 	// if the backup is nil or the included namespaces are nil, return early
 	if backup == nil || backup.Spec.IncludedNamespaces == nil {
 		p.log.Error("Backup or IncludedNamespaces is nil")
@@ -159,7 +152,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 
 	// if the backup is not a hypershift backup, return early
 	if returnEarly := common.ShouldEndPluginExecution(backup.Spec.IncludedNamespaces, p.client, p.log); returnEarly {
-		p.log.Info("Skipping plugin execution - not a hypershift backup")
+		p.log.Info("Skipping hypershift plugin execution - not a hypershift backup")
 		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
 	}
 

--- a/pkg/core/restore.go
+++ b/pkg/core/restore.go
@@ -158,14 +158,10 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	}
 
 	// if the backup is not a hypershift backup, return early
-	// This currently causes the plugin to panic
-
-	// if returnEarly := common.ShouldEndPluginExecution(backup.Spec.IncludedNamespaces, p.client, p.log); returnEarly {
-	// 	return nil, nil
-	// }
-
-	// p.log.Info("WESHAY:END: if return early")
-	// p.log.Debug("WESHAY:END: if return early")
+	if returnEarly := common.ShouldEndPluginExecution(backup.Spec.IncludedNamespaces, p.client, p.log); returnEarly {
+		p.log.Info("Skipping plugin execution - not a hypershift backup")
+		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+	}
 
 	kind := input.Item.GetObjectKind().GroupVersionKind().Kind
 	switch {

--- a/pkg/core/restore.go
+++ b/pkg/core/restore.go
@@ -11,6 +11,7 @@ import (
 	validation "github.com/openshift/hypershift-oadp-plugin/pkg/core/validation"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/sirupsen/logrus"
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/core/restore.go
+++ b/pkg/core/restore.go
@@ -158,11 +158,14 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	}
 
 	// if the backup is not a hypershift backup, return early
-	if returnEarly := common.ShouldEndPluginExecution(backup.Spec.IncludedNamespaces, p.client, p.log); returnEarly {
-		return nil, nil
-	}
-	p.log.Info("WESHAY:END: if return early")
-	p.log.Debug("WESHAY:END: if return early")
+	// This currently causes the plugin to panic
+
+	// if returnEarly := common.ShouldEndPluginExecution(backup.Spec.IncludedNamespaces, p.client, p.log); returnEarly {
+	// 	return nil, nil
+	// }
+
+	// p.log.Info("WESHAY:END: if return early")
+	// p.log.Debug("WESHAY:END: if return early")
 
 	kind := input.Item.GetObjectKind().GroupVersionKind().Kind
 	switch {


### PR DESCRIPTION
When the hypershift plugin is included in the DPA plugin list, the restores are failing to restore the PV data.

## What this PR does / why we need it

## Which issue(s) this PR fixes
[OADP-6147](https://issues.redhat.com//browse/OADP-6147):

## Checklist

- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.