### PR TITLE
OCPBUGS-56430: Include RestoredFromBackup annotation on HostedCluster during restoration

### DIFF
--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -22,14 +22,26 @@ const (
 
 	DefaultK8sSAFilePath string = "/var/run/secrets/kubernetes.io/serviceaccount"
 	KubevirtRHCOSLabel   string = "hypershift.openshift.io/is-kubevirt-rhcos"
+
+	// Integration with Hypershift, more info here: https://github.com/openshift/hypershift/pull/6195
+	HostedClusterRestoredFromBackupAnnotation string = "hypershift.openshift.io/restored-from-backup"
+
+	// hypershift/cluster-api kinds
+	HostedClusterKind         string = "HostedCluster"
+	HostedControlPlaneKind    string = "HostedControlPlane"
+	NodePoolKind              string = "NodePool"
+	PersistentVolumeKind      string = "PersistentVolume"
+	PersistentVolumeClaimKind string = "PersistentVolumeClaim"
+	ClusterDeploymentKind     string = "ClusterDeployment"
+	DataVolumeKind            string = "DataVolume"
 )
 
 var (
 	MainKinds = map[string]bool{
-		"HostedCluster":         true,
-		"NodePool":              true,
-		"PersistentVolume":      true,
-		"PersistentVolumeClaim": true,
+		HostedClusterKind:         true,
+		NodePoolKind:              true,
+		PersistentVolumeKind:      true,
+		PersistentVolumeClaimKind: true,
 	}
 )
 

--- a/pkg/core/backup.go
+++ b/pkg/core/backup.go
@@ -164,7 +164,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *velerov1.Backu
 		p.log.Debugf("Adding Annotation: %s to %s", common.CAPIPausedAnnotationName, metadata.GetName())
 		common.AddAnnotation(metadata, common.CAPIPausedAnnotationName, "true")
 
-	case kind == "HostedControlPlane":
+	case kind == common.HostedControlPlaneKind:
 		hcp := &hyperv1.HostedControlPlane{}
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), hcp); err != nil {
 			return nil, nil, fmt.Errorf("error converting item to HostedControlPlane: %v", err)
@@ -189,14 +189,14 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *velerov1.Backu
 			p.pvTriggered = true
 		}()
 
-	case kind == "ClusterDeployment":
+	case kind == common.ClusterDeploymentKind:
 		if p.Migration && p.hcp.Spec.Platform.Type == hyperv1.AgentPlatform {
 			if err := agent.MigrationTasks(ctx, item, p.client, p.log, p.config, backup); err != nil {
 				return nil, nil, fmt.Errorf("error performing migration tasks for agent platform: %v", err)
 			}
 		}
 
-	case kind == "DataVolume" || kind == "PersistentVolumeClaim":
+	case kind == common.DataVolumeKind || kind == common.PersistentVolumeClaimKind:
 		metadata, err := meta.Accessor(item)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error getting metadata accessor: %v", err)


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds the HostedClusterRestoredFromBackupAnnotation annotation to the HostedCluster object to allow the HostedClusterConfigOperator to manage the recovery in the Hypershift side. More info here: https://github.com/openshift/hypershift/pull/6195

## Which issue(s) this PR fixes
- Fixes [OCPBUGS-56430](https://issues.redhat.com/browse/OCPBUGS-56430)

## Related PRs
- https://github.com/openshift/hypershift/pull/6195