### PR TITLE
NO-JIRA: Fix plugin references pointing to new Konflux images

### DIFF
--- a/examples/AWS/02-dpa-aws.yaml
+++ b/examples/AWS/02-dpa-aws.yaml
@@ -39,5 +39,5 @@ spec:
         - csi
       customPlugins:
         - name: hypershift-oadp-plugin
-          image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest
+          image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
       resourceTimeout: 2h

--- a/examples/BareMetal/02-dpa-bm.yaml
+++ b/examples/BareMetal/02-dpa-bm.yaml
@@ -41,4 +41,4 @@ spec:
         - csi
       customPlugins:
         - name: hypershift-oadp-plugin
-          image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest
+          image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main

--- a/examples/Openstack/02-dpa-osp.yaml
+++ b/examples/Openstack/02-dpa-osp.yaml
@@ -39,5 +39,5 @@ spec:
         - csi
       customPlugins:
         - name: hypershift-oadp-plugin
-          image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest
+          image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
       resourceTimeout: 2h

--- a/examples/kubevirt/02-dpa-kubevirt.yaml
+++ b/examples/kubevirt/02-dpa-kubevirt.yaml
@@ -41,5 +41,5 @@ spec:
         - csi
       customPlugins:
         - name: hypershift-oadp-plugin
-          image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest
+          image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
       resourceTimeout: 2h


### PR DESCRIPTION
## What this PR does / why we need it
- Fix the examples which was pointing to the old plugin image references to the new Konflux repo managed by OADP