### PR TITLE
NO-JIRA: Update fixes to OADP-1.5 branch from main

### DIFF
--- a/examples/AWS/02-dpa-aws.yaml
+++ b/examples/AWS/02-dpa-aws.yaml
@@ -39,5 +39,5 @@ spec:
         - csi
       customPlugins:
         - name: hypershift-oadp-plugin
-          image: quay.io/hypershift/hypershift-oadp-plugin:latest
+          image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest
       resourceTimeout: 2h

--- a/examples/BareMetal/02-dpa-bm.yaml
+++ b/examples/BareMetal/02-dpa-bm.yaml
@@ -41,4 +41,4 @@ spec:
         - csi
       customPlugins:
         - name: hypershift-oadp-plugin
-          image: quay.io/hypershift/hypershift-oadp-plugin:latest
+          image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest

--- a/examples/Openstack/02-dpa-osp.yaml
+++ b/examples/Openstack/02-dpa-osp.yaml
@@ -39,5 +39,5 @@ spec:
         - csi
       customPlugins:
         - name: hypershift-oadp-plugin
-          image: quay.io/hypershift/hypershift-oadp-plugin:latest
+          image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest
       resourceTimeout: 2h

--- a/examples/kubevirt/02-dpa-kubevirt.yaml
+++ b/examples/kubevirt/02-dpa-kubevirt.yaml
@@ -41,5 +41,5 @@ spec:
         - csi
       customPlugins:
         - name: hypershift-oadp-plugin
-          image: quay.io/hypershift/hypershift-oadp-plugin:latest
+          image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest
       resourceTimeout: 2h

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/vmware-tanzu/velero v1.14.0
 	k8s.io/api v0.32.3
+	k8s.io/apiextensions-apiserver v0.31.3
 	sigs.k8s.io/controller-runtime v0.19.3
 )
 
@@ -33,7 +34,6 @@ require (
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
-	k8s.io/apiextensions-apiserver v0.31.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -734,8 +734,8 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 k8s.io/api v0.23.3/go.mod h1:w258XdGyvCmnBj/vGzQMj6kzdufJZVUwEM1U2fRJwSQ=
 k8s.io/api v0.32.3 h1:Hw7KqxRusq+6QSplE3NYG4MBxZw1BZnq4aP4cJVINls=
 k8s.io/api v0.32.3/go.mod h1:2wEDTXADtm/HA7CCMD8D8bK4yuBUptzaRhYcYEEYA3k=
-k8s.io/apiextensions-apiserver v0.31.0 h1:fZgCVhGwsclj3qCw1buVXCV6khjRzKC5eCFt24kyLSk=
-k8s.io/apiextensions-apiserver v0.31.0/go.mod h1:b9aMDEYaEe5sdK+1T0KU78ApR/5ZVp4i56VacZYEHxk=
+k8s.io/apiextensions-apiserver v0.31.3 h1:+GFGj2qFiU7rGCsA5o+p/rul1OQIq6oYpQw4+u+nciE=
+k8s.io/apiextensions-apiserver v0.31.3/go.mod h1:2DSpFhUZZJmn/cr/RweH1cEVVbzFw9YBu4T+U3mf1e4=
 k8s.io/apimachinery v0.23.3/go.mod h1:BEuFMMBaIbcOqVIJqNZJXGFTP4W6AycEpb5+m/97hrM=
 k8s.io/apimachinery v0.32.3 h1:JmDuDarhDmA/Li7j3aPrwhpNBA94Nvk5zLeOge9HH1U=
 k8s.io/apimachinery v0.32.3/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=

--- a/main.go
+++ b/main.go
@@ -6,6 +6,14 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/plugin/framework"
 )
 
+func configureLogger(logger logrus.FieldLogger) logrus.FieldLogger {
+	return logger.WithFields(
+		logrus.Fields{
+			"type": "hcp-plugin",
+		},
+	)
+}
+
 func main() {
 	framework.NewServer().
 		RegisterBackupItemAction("hypershift-oadp-plugin/backup-item-action", newHCPBackupPlugin).
@@ -14,11 +22,9 @@ func main() {
 }
 
 func newHCPBackupPlugin(logger logrus.FieldLogger) (interface{}, error) {
-	logger.Info("Initializing HCP Backup Plugin")
-	return core.NewBackupPlugin()
+	return core.NewBackupPlugin(configureLogger(logger))
 }
 
 func newHCPRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
-	logger.Info("Initializing HCP Restore Plugin")
-	return core.NewRestorePlugin()
+	return core.NewRestorePlugin(configureLogger(logger))
 }

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -22,14 +22,26 @@ const (
 
 	DefaultK8sSAFilePath string = "/var/run/secrets/kubernetes.io/serviceaccount"
 	KubevirtRHCOSLabel   string = "hypershift.openshift.io/is-kubevirt-rhcos"
+
+	// Integration with Hypershift, more info here: https://github.com/openshift/hypershift/pull/6195
+	HostedClusterRestoredFromBackupAnnotation string = "hypershift.openshift.io/restored-from-backup"
+
+	// hypershift/cluster-api kinds
+	HostedClusterKind         string = "HostedCluster"
+	HostedControlPlaneKind    string = "HostedControlPlane"
+	NodePoolKind              string = "NodePool"
+	PersistentVolumeKind      string = "PersistentVolume"
+	PersistentVolumeClaimKind string = "PersistentVolumeClaim"
+	ClusterDeploymentKind     string = "ClusterDeployment"
+	DataVolumeKind            string = "DataVolume"
 )
 
 var (
 	MainKinds = map[string]bool{
-		"HostedCluster":         true,
-		"NodePool":              true,
-		"PersistentVolume":      true,
-		"PersistentVolumeClaim": true,
+		HostedClusterKind:         true,
+		NodePoolKind:              true,
+		PersistentVolumeKind:      true,
+		PersistentVolumeClaimKind: true,
 	}
 )
 

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -138,7 +138,7 @@ func TestManagePauseHostedCluster(t *testing.T) {
 			client := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.hcList).Build()
 			log := logrus.New()
 
-			err := ManagePauseHostedCluster(context.TODO(), client, log, tt.paused, tt.namespaces)
+			err := UpdateHostedCluster(context.TODO(), client, log, tt.paused, tt.namespaces)
 			if tt.expectErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -148,6 +148,7 @@ func TestManagePauseHostedCluster(t *testing.T) {
 					err := client.Get(context.TODO(), types.NamespacedName{Name: hc.Name, Namespace: hc.Namespace}, updatedHC)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(updatedHC.Spec.PausedUntil).To(Equal(ptr.To(tt.paused)))
+					g.Expect(updatedHC.Annotations[HostedClusterRestoredFromBackupAnnotation]).To(BeEmpty())
 				}
 			}
 		})
@@ -222,7 +223,7 @@ func TestManagePauseNodepools(t *testing.T) {
 			client := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.npList).Build()
 			log := logrus.New()
 
-			err := ManagePauseNodepools(context.TODO(), client, log, tt.paused, tt.namespaces)
+			err := UpdateNodepools(context.TODO(), client, log, tt.paused, tt.namespaces)
 			if tt.expectErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/pkg/core/backup.go
+++ b/pkg/core/backup.go
@@ -164,7 +164,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *velerov1.Backu
 		p.log.Debugf("Adding Annotation: %s to %s", common.CAPIPausedAnnotationName, metadata.GetName())
 		common.AddAnnotation(metadata, common.CAPIPausedAnnotationName, "true")
 
-	case kind == "HostedControlPlane":
+	case kind == common.HostedControlPlaneKind:
 		hcp := &hyperv1.HostedControlPlane{}
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), hcp); err != nil {
 			return nil, nil, fmt.Errorf("error converting item to HostedControlPlane: %v", err)
@@ -189,14 +189,14 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *velerov1.Backu
 			p.pvTriggered = true
 		}()
 
-	case kind == "ClusterDeployment":
+	case kind == common.ClusterDeploymentKind:
 		if p.Migration && p.hcp.Spec.Platform.Type == hyperv1.AgentPlatform {
 			if err := agent.MigrationTasks(ctx, item, p.client, p.log, p.config, backup); err != nil {
 				return nil, nil, fmt.Errorf("error performing migration tasks for agent platform: %v", err)
 			}
 		}
 
-	case kind == "DataVolume" || kind == "PersistentVolumeClaim":
+	case kind == common.DataVolumeKind || kind == common.PersistentVolumeClaimKind:
 		metadata, err := meta.Accessor(item)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error getting metadata accessor: %v", err)

--- a/pkg/core/backup.go
+++ b/pkg/core/backup.go
@@ -44,19 +44,22 @@ type BackupPlugin struct {
 }
 
 // NewBackupPlugin instantiates BackupPlugin.
-func NewBackupPlugin() (*BackupPlugin, error) {
+func NewBackupPlugin(logger logrus.FieldLogger) (*BackupPlugin, error) {
 	var (
 		err error
-		log = logrus.New()
 	)
-	log.SetLevel(logrus.DebugLevel)
 
-	log.Infof("initializing hypershift OADP backup plugin")
+	logger = logger.WithFields(logrus.Fields{
+		"process": "backup",
+	})
+
+	logger.Info("Initializing HCP Backup Plugin")
+
 	client, err := common.GetClient()
 	if err != nil {
 		return nil, fmt.Errorf("error recovering the k8s client: %s", err.Error())
 	}
-	log.Infof("client recovered")
+	logger.Infof("client recovered")
 	ctx := context.Background()
 
 	pluginConfig := corev1.ConfigMap{}
@@ -70,16 +73,23 @@ func NewBackupPlugin() (*BackupPlugin, error) {
 		if !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("error getting plugin configuration: %s", err.Error())
 		}
-		log.Infof("configuration for hypershift OADP plugin not found")
+		logger.Infof("configuration for hypershift OADP plugin not found")
+	}
+
+	validator := &validation.BackupPluginValidator{}
+	if l, ok := logger.(*logrus.Logger); ok {
+		validator.Log = l
+	} else {
+		validator.Log = logrus.New()
 	}
 
 	bp := &BackupPlugin{
-		log:       log,
+		log:       logger,
 		client:    client,
 		config:    pluginConfig.Data,
 		finished:  false,
 		ctx:       ctx,
-		validator: &validation.BackupPluginValidator{Log: log},
+		validator: validator,
 	}
 
 	if bp.BackupOptions, err = bp.validator.ValidatePluginConfig(bp.config); err != nil {
@@ -92,11 +102,13 @@ func NewBackupPlugin() (*BackupPlugin, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error parsing pluginVerbosityLevel: %s", err.Error())
 		}
-		log.Infof("pluginVerbosityLevel set to %s", parsedLevel)
-		log.SetLevel(parsedLevel)
+		logger.Infof("pluginVerbosityLevel set to %s", parsedLevel)
+		if l, ok := logger.(*logrus.Logger); ok {
+			l.SetLevel(parsedLevel)
+		}
 	}
 
-	bp.log = log.WithField("type", "core-backup")
+	bp.log.Infof("Backup plugin initialized with log level: %s", logrus.GetLevel())
 
 	return bp, nil
 }
@@ -161,8 +173,8 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *velerov1.Backu
 		if err != nil {
 			return nil, nil, fmt.Errorf("error getting metadata accessor: %v", err)
 		}
-		p.log.Debugf("Adding Annotation: %s to %s", common.CAPIPausedAnnotationName, metadata.GetName())
 		common.AddAnnotation(metadata, common.CAPIPausedAnnotationName, "true")
+		p.log.Infof("Added CAPI Paused Annotation: %s to %s", common.CAPIPausedAnnotationName, metadata.GetName())
 
 	case kind == common.HostedControlPlaneKind:
 		hcp := &hyperv1.HostedControlPlane{}
@@ -175,19 +187,28 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *velerov1.Backu
 		}
 
 	case common.MainKinds[kind]:
-		// Pausing HostedClusters
-		if err := common.ManagePauseHostedCluster(ctx, p.client, p.log, "true", backup.Spec.IncludedNamespaces); err != nil {
-			return nil, nil, fmt.Errorf("error pausing HostedClusters: %v", err)
+		// Updating HostedClusters
+		if err := common.UpdateHostedCluster(ctx, p.client, p.log, "true", backup.Spec.IncludedNamespaces); err != nil {
+			return nil, nil, fmt.Errorf("error updating HostedClusters: %v", err)
 		}
 
-		// Pausing NodePools
-		if err := common.ManagePauseNodepools(ctx, p.client, p.log, "true", backup.Spec.IncludedNamespaces); err != nil {
-			return nil, nil, fmt.Errorf("error pausing NodePools: %v", err)
+		// Updating NodePools
+		if err := common.UpdateNodepools(ctx, p.client, p.log, "true", backup.Spec.IncludedNamespaces); err != nil {
+			return nil, nil, fmt.Errorf("error updating NodePools: %v", err)
 		}
 
 		defer func() {
 			p.pvTriggered = true
 		}()
+
+		if kind == common.HostedClusterKind {
+			metadata, err := meta.Accessor(item)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error getting metadata accessor: %v", err)
+			}
+			common.AddAnnotation(metadata, common.HostedClusterRestoredFromBackupAnnotation, "")
+			p.log.Infof("Added restore annotation to HostedCluster %s", metadata.GetName())
+		}
 
 	case kind == common.ClusterDeploymentKind:
 		if p.Migration && p.hcp.Spec.Platform.Type == hyperv1.AgentPlatform {
@@ -205,7 +226,6 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *velerov1.Backu
 		if _, exists := labels[common.KubevirtRHCOSLabel]; exists {
 			return nil, nil, nil
 		}
-
 	}
 
 	if (backup.Spec.DefaultVolumesToFsBackup != nil && !*backup.Spec.DefaultVolumesToFsBackup) || backup.Spec.DefaultVolumesToFsBackup == nil {
@@ -245,15 +265,15 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *velerov1.Backu
 	}
 
 	if p.finished && !p.Migration {
-		p.log.Debug("Volume backup is done, unpausing HC and NPs")
-		// Unpausing NodePools
-		if err := common.ManagePauseNodepools(ctx, p.client, p.log, "false", backup.Spec.IncludedNamespaces); err != nil {
-			return nil, nil, fmt.Errorf("error unpausing NodePools: %v", err)
+		p.log.Debug("Volume backup is done, updating HC and NPs")
+		// updating NodePools
+		if err := common.UpdateNodepools(ctx, p.client, p.log, "false", backup.Spec.IncludedNamespaces); err != nil {
+			return nil, nil, fmt.Errorf("error updating NodePools: %v", err)
 		}
 
-		// Unpausing HostedClusters
-		if err := common.ManagePauseHostedCluster(ctx, p.client, p.log, "false", backup.Spec.IncludedNamespaces); err != nil {
-			return nil, nil, fmt.Errorf("error unpausing HostedClusters: %v", err)
+		// updating HostedClusters
+		if err := common.UpdateHostedCluster(ctx, p.client, p.log, "false", backup.Spec.IncludedNamespaces); err != nil {
+			return nil, nil, fmt.Errorf("error updating HostedClusters: %v", err)
 		}
 	}
 

--- a/pkg/core/backup.go
+++ b/pkg/core/backup.go
@@ -144,7 +144,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *velerov1.Backu
 	p.log.Debug("Entering Hypershift backup plugin")
 	ctx := context.Context(p.ctx)
 
-	if returnEarly := common.ShouldEndPluginExecution(backup.Spec.IncludedNamespaces, p.client, p.log); returnEarly {
+	if returnEarly := common.ShouldEndPluginExecution(ctx, backup, p.client, p.log); returnEarly {
 		return item, nil, nil
 	}
 

--- a/pkg/core/restore.go
+++ b/pkg/core/restore.go
@@ -160,7 +160,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	}
 
 	// if the backup is not a hypershift backup, return early
-	if returnEarly := common.ShouldEndPluginExecution(backup.Spec.IncludedNamespaces, p.client, p.log); returnEarly {
+	if returnEarly := common.ShouldEndPluginExecution(ctx, backup, p.client, p.log); returnEarly {
 		p.log.Info("Skipping hypershift plugin execution - not a hypershift backup")
 		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -451,7 +451,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 k8s.io/api/storagemigration/v1alpha1
-# k8s.io/apiextensions-apiserver v0.31.0
+# k8s.io/apiextensions-apiserver v0.31.3
 ## explicit; go 1.22.0
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1


### PR DESCRIPTION
## What this PR does / why we need it
- In order to catch up with the new fixes delivered to Main branch this PR will sync the oadp-1.5 branch with the right fixes

## Includes these changes
- [OCPBUGS-56430: Include RestoredFromBackup annotation on HostedCluster during restoration](https://github.com/openshift/hypershift-oadp-plugin/commit/b6f97482143d4d8d6e881ddc857ab1805e31af2e)
- [OCPBUGS-56430: Fix adding restoredFromBackup annotation to HC](https://github.com/openshift/hypershift-oadp-plugin/commit/18ce375c78d9c5e7e2147cea219a7885707aff20)
- [OCPBUGS-57418: Fix detection of ShouldEndPluginExecution during HCP and not HCP DR procedures](https://github.com/openshift/hypershift-oadp-plugin/commit/36d30aea41f8ea9a50d1ca293e719723b0292c34)
