### PR TITLE
OADP-6248: use the namespace where the plugin runs to get find backups

### DIFF
--- a/pkg/core/restore.go
+++ b/pkg/core/restore.go
@@ -30,6 +30,7 @@ type RestorePlugin struct {
 	config    map[string]string
 	validator validation.RestoreValidator
 	fsBackup  bool
+	namespace string
 
 	*plugtypes.RestoreOptions
 }
@@ -91,6 +92,7 @@ func NewRestorePlugin(logger logrus.FieldLogger) (*RestorePlugin, error) {
 		fsBackup:  false,
 		config:    pluginConfig.Data,
 		validator: validator,
+		namespace: ns,
 	}
 
 	if rp.RestoreOptions, err = rp.validator.ValidatePluginConfig(rp.config); err != nil {
@@ -129,7 +131,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	err := p.client.Get(
 		ctx,
 		types.NamespacedName{
-			Namespace: input.Restore.Namespace,
+			Namespace: p.namespace,
 			Name:      input.Restore.Spec.BackupName,
 		},
 		backup,


### PR DESCRIPTION
* a bug was introduced by yours truly where backups were searched by using restore specs namespace ( I think ) in:
https://github.com/openshift/hypershift-oadp-plugin/pull/57

## What this PR does / why we need it
set the namespace where backups should be searched.

## Which issue(s) this PR fixes
Fixes #[OADP-6248](https://issues.redhat.com//browse/OADP-6248)

## Checklist

- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.