### PR TITLE
OADP-6248: fix restore after consult

### DIFF
--- a/pkg/core/restore.go
+++ b/pkg/core/restore.go
@@ -146,7 +146,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
 	}
 
-	// if the backup is nil or the included namespaces are nil, return early
+	// if the IncludedNamespaces field is nil, return error
 	if backup.Spec.IncludedNamespaces == nil {
 		p.log.Error("IncludedNamespaces from backup object is nil")
 		return nil, fmt.Errorf("included namespaces from backup object is nil")


### PR DESCRIPTION
Exit the hypershift plugin before if the included namespace is checked

## What this PR does / why we need it
https://issues.redhat.com/browse/OADP-6248

## Which issue(s) this PR fixes
Fixes # https://issues.redhat.com/browse/OADP-6248

## Checklist

- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.