### PR TITLE
fix: initialize NPaused and HCPaused pointers in BackupPluginValidator

### DIFF
--- a/pkg/core/backup.go
+++ b/pkg/core/backup.go
@@ -91,6 +91,8 @@ func NewBackupPlugin(logger logrus.FieldLogger) (*BackupPlugin, error) {
 		PVBackupFinished:    ptr.To(false),
 		DUStarted:           ptr.To(false),
 		DUFinished:          ptr.To(false),
+		NPaused:             ptr.To(false),
+		HCPaused:            ptr.To(false),
 	}
 
 	bp := &BackupPlugin{


### PR DESCRIPTION
The BackupPluginValidator struct was missing initialization for NPaused and HCPaused
pointer fields, causing a nil pointer dereference panic when these fields were accessed
in reconcileStandardDataMover at line 296.

This fix ensures the pointers are always valid when accessed during backup operations.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

## What this PR does / why we need it

## Which issue(s) this PR fixes
Fixes #

## Checklist

- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.