### PR TITLE
fix: add velero to renovate ignoreDeps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,10 @@
   "branchPrefix": "konflux/mintmaker/",
   "labels": ["area/ci-tooling", "ok-to-test"],
   "pruneStaleBranches": true,
+  "ignoreDeps": [
+    "github.com/vmware-tanzu/velero",
+    "github.com/openshift/velero"
+  ],
   "packageRules": [
     {
       "description": "Group Kubernetes dependencies (k8s.io, sigs.k8s.io)",


### PR DESCRIPTION
## Summary
- Add `github.com/vmware-tanzu/velero` and `github.com/openshift/velero` to `ignoreDeps` in `renovate.json`
- Prevents Renovate/MintMaker from creating PRs that update velero to incompatible versions
- The openshift/velero fork is managed via `replace` directive and must track specific `oadp-*` branches manually

Closes #223

## Context
Renovate PRs #215 and #216 updated velero to v1.2.0 which removed the `v2alpha1` API package that the plugin depends on. The velero dependency should be managed manually to track the correct `openshift/velero` branch.

> [!Note]
> Responses generated with Claude