### PR TITLE
Add CODEOWNERS file based on OWNERS approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS - Code ownership for hypershift-oadp-plugin
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Each line is a file pattern followed by one or more owners.
+
+* @enxebre @csrwng @sjenning @muraee @bryan-cox @jparrill @celebdor @kaovilai


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` file based on approvers from `OWNERS` file
- This will automatically request reviews from code owners when PRs are created

## Approvers
All files (`*`) are owned by:
@enxebre @csrwng @sjenning @muraee @bryan-cox @jparrill @celebdor @kaovilai

🤖 Generated with [Claude Code](https://claude.com/claude-code)