### PR TITLE
[oadp-1.6] fix: scope go.work gitignore patterns to root only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@
 # vendor/
 
 # Go workspace file
-go.work
-go.work.sum
+/go.work
+/go.work.sum
 
 # env file
 .env


### PR DESCRIPTION
## Summary
- Scope `go.work` and `go.work.sum` gitignore patterns to root-only (`/go.work`) so vendor copies (e.g. `vendor/github.com/go-openapi/swag/go.work`) are not excluded

## Problem
Global `go.work` patterns cause vendor files to be git-ignored, breaking Hermeto vendor consistency checks.

Fixes https://github.com/openshift/hypershift-oadp-plugin/issues/265

> [!Note]
> Responses generated with Claude