### PR TITLE
fix: use golang-1.25-openshift-4.22 builder image on oadp-1.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20 AS build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.22 AS build
 WORKDIR /go/src/github.com/openshift/hypershift-oadp-plugin
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/hypershift-oadp-plugin .

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.20 AS build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20 AS build
 WORKDIR /go/src/github.com/openshift/hypershift-oadp-plugin
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/hypershift-oadp-plugin .


### PR DESCRIPTION
## What this PR does / why we need it

The CI image build on the oadp-1.5 branch is failing because the Dockerfile
references a builder image tag that does not exist:

`registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.20`

The `golang-1.25` builder is only available with the `openshift-4.22` tag.
The OCP version in the builder tag does not affect the built binary.

This updates the builder FROM line to use `rhel-9-release-golang-1.25-openshift-4.22`,
matching what the oadp-1.6 branch already uses.

## Which issue(s) this PR fixes

Fixes CI build failure:
`dockerimage.image.openshift.io "quay.io/openshift/ci:openshift_release_rhel-9-release-golang-1.25-openshift-4.20" not found`

## Checklist

- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.