### PR TITLE
Bump Go version from 1.25 to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.22 AS build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.26-openshift-4.23 AS build
 WORKDIR /go/src/github.com/openshift/hypershift-oadp-plugin
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/hypershift-oadp-plugin .

--- a/Dockerfile.oadp
+++ b/Dockerfile.oadp
@@ -1,5 +1,5 @@
-#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25)
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26)
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 AS builder
 
 COPY . /workspace
 WORKDIR /workspace/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hypershift-oadp-plugin
 
-go 1.25.7
+go 1.26.0
 
 toolchain go1.26.3
 


### PR DESCRIPTION
Upstream velero (main) requires `go 1.26.0`. This updates go.mod and both Dockerfiles to use Go 1.26 builder images, ahead of the velero dependency rebase in #295.

**Changes:**
- `go.mod`: `go 1.25.7` → `go 1.26.0`
- `Dockerfile`: `golang-1.25-openshift-4.22` → `golang-1.26-openshift-4.22`
- `Dockerfile.oadp`: `rhel_9_golang_1.25` → `rhel_9_golang_1.26`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the application build environment to Go 1.26.
  * Updated container build configurations to the corresponding OpenShift Go 1.26 release (including the OpenShift patch level).
  * No runtime behavior changes were included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->